### PR TITLE
fix is_rust_rile

### DIFF
--- a/utoipauto-core/src/file_utils.rs
+++ b/utoipauto-core/src/file_utils.rs
@@ -44,7 +44,13 @@ pub fn parse_files<T: Into<PathBuf>>(path: T) -> Result<Vec<(String, syn::File)>
 }
 
 fn is_rust_file(path: &Path) -> bool {
-    path.is_file() && path.extension().unwrap().to_str().unwrap().eq("rs")
+    path.is_file() && match path.extension() {
+        Some(ext) => match ext.to_str() {
+            Some(ext) => ext.eq("rs"),
+            None => false,
+        },
+        None => false,
+    }
 }
 
 /// Extract the module name from the file path


### PR DESCRIPTION
Fixes is_rust_file so it does not throw 'called `Option::unwrap()` on a `None` value' on a file with no extension